### PR TITLE
Resets Default Block Event for Additional Flowcharts

### DIFF
--- a/Assets/Fungus/Flowchart/Scripts/Flowchart.cs
+++ b/Assets/Fungus/Flowchart/Scripts/Flowchart.cs
@@ -20,6 +20,11 @@ namespace Fungus
 		 */
         public const string CURRENT_VERSION = "1.0";
 
+        /**
+        * The name of the initial block in a new flowchart.
+        */
+        public const string DEFAULT_BLOCK_NAME = "New Block";
+
 		/**
 		 * Variable to track flowchart's version and if initial set up has completed.
 		 */
@@ -252,6 +257,7 @@ namespace Fungus
             {
                 // Version never set, so we are initializing on first creation or this flowchart is pre-versioning.
                 case null:
+                case "":
                     Initialize();
                     break;
             }
@@ -263,7 +269,7 @@ namespace Fungus
 	    {
             // If there are other flowcharts in the scene and the selected block has the default name, then this is probably a new block.
             // Reset the event handler of the new flowchart's default block to avoid crashes.
-            if (selectedBlock && cachedFlowcharts.Count > 1 && selectedBlock.name == "New Block")
+            if (selectedBlock && cachedFlowcharts.Count > 1 && selectedBlock.blockName == DEFAULT_BLOCK_NAME)
             {
                 selectedBlock.eventHandler = null;
             }

--- a/Assets/Fungus/Flowchart/Scripts/Flowchart.cs
+++ b/Assets/Fungus/Flowchart/Scripts/Flowchart.cs
@@ -261,6 +261,12 @@ namespace Fungus
 
 	    protected virtual void Initialize()
 	    {
+            // If there are other flowcharts in the scene and the selected block has the default name, then this is probably a new block.
+            // Reset the event handler of the new flowchart's default block to avoid crashes.
+            if (selectedBlock && cachedFlowcharts.Count > 1 && selectedBlock.name == "New Block")
+            {
+                selectedBlock.eventHandler = null;
+            }
         }
 
 		protected virtual Block CreateBlockComponent(GameObject parent)

--- a/Assets/Fungus/Flowchart/Scripts/Flowchart.cs
+++ b/Assets/Fungus/Flowchart/Scripts/Flowchart.cs
@@ -15,6 +15,17 @@ namespace Fungus
 	[ExecuteInEditMode]
 	public class Flowchart : MonoBehaviour 
 	{
+        /**
+		 * Current version used to compare with the previous version so older versions can be custom-updated from previous versions.
+		 */
+        public const string CURRENT_VERSION = "1.0";
+
+		/**
+		 * Variable to track flowchart's version and if initial set up has completed.
+		 */
+		[HideInInspector]
+		public string version;
+
 		/**
 		 * Scroll position of Flowchart editor window.
 		 */
@@ -143,6 +154,7 @@ namespace Fungus
 
 			CheckItemIds();
 			CleanupComponents();
+		    UpdateVersion();
 		}
 
 		public virtual void OnDisable()
@@ -230,6 +242,26 @@ namespace Fungus
 				}
 			}
 		}
+
+        private void UpdateVersion()
+        {
+            // If versions match, then we are already using the latest.
+            if (version == CURRENT_VERSION) return;
+
+            switch (version)
+            {
+                // Version never set, so we are initializing on first creation or this flowchart is pre-versioning.
+                case null:
+                    Initialize();
+                    break;
+            }
+
+            version = CURRENT_VERSION;
+        }
+
+	    protected virtual void Initialize()
+	    {
+        }
 
 		protected virtual Block CreateBlockComponent(GameObject parent)
 		{


### PR DESCRIPTION
Added a hidden serialized `version` field, an `UpdateVersion()` function, and an overridable `Initialize()` function to the Flowchart component that allow for custom upgrades from previous versions as well as a one-time initialization after each flowchart instance creation.

Updated the default initialization function to reset the event handler of the default block on the newly created flowchart if previous flowcharts are found in `cachedFlowcharts` and the default block uses the default block name (to avoid resetting older previously existing flowcharts).

![image](https://cloud.githubusercontent.com/assets/556111/8604759/76d931aa-2635-11e5-8d83-31c35764eca9.png)
