### PR TITLE
Added a Hide Commands property to Flowchart

### DIFF
--- a/Assets/Fungus/Flowchart/Editor/FlowchartEditor.cs
+++ b/Assets/Fungus/Flowchart/Editor/FlowchartEditor.cs
@@ -25,6 +25,7 @@ namespace Fungus
 		protected SerializedProperty saveSelectionProp;
 		protected SerializedProperty localizationIdProp;
 		protected SerializedProperty variablesProp;
+		protected SerializedProperty hideCommandsProp;
 
 		protected Texture2D addTexture;
 				
@@ -37,6 +38,7 @@ namespace Fungus
 			saveSelectionProp = serializedObject.FindProperty("saveSelection");
 			localizationIdProp = serializedObject.FindProperty("localizationId");
 			variablesProp = serializedObject.FindProperty("variables");
+			hideCommandsProp = serializedObject.FindProperty("hideCommands");
 
 			addTexture = Resources.Load("Icons/add_small") as Texture2D;
 		}
@@ -55,6 +57,10 @@ namespace Fungus
 			EditorGUILayout.PropertyField(stepPauseProp);
 			EditorGUILayout.PropertyField(saveSelectionProp);
 			EditorGUILayout.PropertyField(localizationIdProp);
+
+			// Show list of commands to hide in Add Command menu
+			ReorderableListGUI.Title(new GUIContent(hideCommandsProp.displayName, hideCommandsProp.tooltip));
+			ReorderableListGUI.ListField(hideCommandsProp);
 
 			GUILayout.BeginHorizontal();
 			GUILayout.FlexibleSpace();

--- a/Assets/Fungus/Flowchart/Scripts/Flowchart.cs
+++ b/Assets/Fungus/Flowchart/Scripts/Flowchart.cs
@@ -125,6 +125,12 @@ namespace Fungus
 		public string localizationId = "";
 
 		/**
+		 * List of commands to hide in the Add Command menu. Use this to restrict the set of commands available when editing a Flowchart.
+		 */
+		[Tooltip("List of commands to hide in the Add Command menu. Use this to restrict the set of commands available when editing a Flowchart.")]
+		public List<string> hideCommands = new List<string>();
+
+		/**
 		 * Cached list of flowchart objects in the scene for fast lookup
 		 */
 		public static List<Flowchart> cachedFlowcharts = new List<Flowchart>();
@@ -843,6 +849,16 @@ namespace Fungus
 		 */
 		public virtual bool IsCommandSupported(CommandInfoAttribute commandInfo)
 		{
+			foreach (string key in hideCommands)
+			{
+				// Match on category or command name (case insensitive)
+				if (String.Compare(commandInfo.Category, key, StringComparison.OrdinalIgnoreCase) == 0 ||
+				    String.Compare(commandInfo.CommandName, key, StringComparison.OrdinalIgnoreCase) == 0)
+				{
+					return false;
+				}
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
Any command or category name that matches an item in the list will not
appear in the add command menu.