### PR TITLE
Set say dialog for character

### DIFF
--- a/Assets/Fungus/Narrative/Editor/CharacterEditor.cs
+++ b/Assets/Fungus/Narrative/Editor/CharacterEditor.cs
@@ -16,9 +16,9 @@ namespace Fungus
 		protected SerializedProperty portraitsProp;
 		protected SerializedProperty portraitsFaceProp;
 		protected SerializedProperty descriptionProp;
-        protected SerializedProperty setSayDialogProp;
+		protected SerializedProperty setSayDialogProp;
 
-        protected virtual void OnEnable()
+		protected virtual void OnEnable()
 		{
 			nameTextProp = serializedObject.FindProperty ("nameText");
 			nameColorProp = serializedObject.FindProperty ("nameColor");
@@ -26,8 +26,8 @@ namespace Fungus
 			portraitsProp = serializedObject.FindProperty ("portraits");
 			portraitsFaceProp = serializedObject.FindProperty ("portraitsFace");
 			descriptionProp = serializedObject.FindProperty ("description");
-            setSayDialogProp = serializedObject.FindProperty("setSayDialog");
-        }
+			setSayDialogProp = serializedObject.FindProperty("setSayDialog");
+		}
 
 		public override void OnInspectorGUI() 
 		{
@@ -38,11 +38,11 @@ namespace Fungus
 			EditorGUILayout.PropertyField(nameTextProp, new GUIContent("Name Text", "Name of the character display in the dialog"));
 			EditorGUILayout.PropertyField(nameColorProp, new GUIContent("Name Color", "Color of name text display in the dialog"));
 			EditorGUILayout.PropertyField(soundEffectProp, new GUIContent("Sound Effect", "Sound to play when the character is talking. Overrides the setting in the Dialog."));
-            EditorGUILayout.PropertyField(setSayDialogProp);
-            EditorGUILayout.PropertyField(descriptionProp, new GUIContent("Description", "Notes about this story character (personality, attibutes, etc.)"));
+			EditorGUILayout.PropertyField(setSayDialogProp);
+			EditorGUILayout.PropertyField(descriptionProp, new GUIContent("Description", "Notes about this story character (personality, attibutes, etc.)"));
 
-            if (t.portraits != null &&
-			    t.portraits.Count > 0)
+			if (t.portraits != null &&
+				t.portraits.Count > 0)
 			{
 				t.profileSprite = t.portraits[0];
 			}

--- a/Assets/Fungus/Narrative/Editor/CharacterEditor.cs
+++ b/Assets/Fungus/Narrative/Editor/CharacterEditor.cs
@@ -16,8 +16,9 @@ namespace Fungus
 		protected SerializedProperty portraitsProp;
 		protected SerializedProperty portraitsFaceProp;
 		protected SerializedProperty descriptionProp;
+        protected SerializedProperty setSayDialogProp;
 
-		protected virtual void OnEnable()
+        protected virtual void OnEnable()
 		{
 			nameTextProp = serializedObject.FindProperty ("nameText");
 			nameColorProp = serializedObject.FindProperty ("nameColor");
@@ -25,7 +26,8 @@ namespace Fungus
 			portraitsProp = serializedObject.FindProperty ("portraits");
 			portraitsFaceProp = serializedObject.FindProperty ("portraitsFace");
 			descriptionProp = serializedObject.FindProperty ("description");
-		}
+            setSayDialogProp = serializedObject.FindProperty("setSayDialog");
+        }
 
 		public override void OnInspectorGUI() 
 		{
@@ -36,8 +38,10 @@ namespace Fungus
 			EditorGUILayout.PropertyField(nameTextProp, new GUIContent("Name Text", "Name of the character display in the dialog"));
 			EditorGUILayout.PropertyField(nameColorProp, new GUIContent("Name Color", "Color of name text display in the dialog"));
 			EditorGUILayout.PropertyField(soundEffectProp, new GUIContent("Sound Effect", "Sound to play when the character is talking. Overrides the setting in the Dialog."));
-			EditorGUILayout.PropertyField(descriptionProp, new GUIContent("Description", "Notes about this story character (personality, attibutes, etc.)"));
-			if (t.portraits != null &&
+            EditorGUILayout.PropertyField(setSayDialogProp);
+            EditorGUILayout.PropertyField(descriptionProp, new GUIContent("Description", "Notes about this story character (personality, attibutes, etc.)"));
+
+            if (t.portraits != null &&
 			    t.portraits.Count > 0)
 			{
 				t.profileSprite = t.portraits[0];

--- a/Assets/Fungus/Narrative/Scripts/Character.cs
+++ b/Assets/Fungus/Narrative/Scripts/Character.cs
@@ -16,9 +16,12 @@ namespace Fungus
 		public Sprite profileSprite;
 		public List<Sprite> portraits;
 		public FacingDirection portraitsFace;	
-		public PortraitState state;		
+		public PortraitState state;
+        
+        [Tooltip("Sets the active Say dialog with a reference to a Say Dialog object in the scene. All story text will now display using this Say Dialog.")]
+        public SayDialog setSayDialog;
 
-		[FormerlySerializedAs("notes")]
+        [FormerlySerializedAs("notes")]
 		[TextArea(5,10)]
 		public string description;
 

--- a/Assets/Fungus/Narrative/Scripts/Character.cs
+++ b/Assets/Fungus/Narrative/Scripts/Character.cs
@@ -15,13 +15,13 @@ namespace Fungus
 		public AudioClip soundEffect;
 		public Sprite profileSprite;
 		public List<Sprite> portraits;
-		public FacingDirection portraitsFace;	
+		public FacingDirection portraitsFace;
 		public PortraitState state;
-        
-        [Tooltip("Sets the active Say dialog with a reference to a Say Dialog object in the scene. All story text will now display using this Say Dialog.")]
-        public SayDialog setSayDialog;
 
-        [FormerlySerializedAs("notes")]
+		[Tooltip("Sets the active Say dialog with a reference to a Say Dialog object in the scene. All story text will now display using this Say Dialog.")]
+		public SayDialog setSayDialog;
+
+		[FormerlySerializedAs("notes")]
 		[TextArea(5,10)]
 		public string description;
 
@@ -34,7 +34,7 @@ namespace Fungus
 				activeCharacters.Add(this);
 			}
 		}
-		
+
 		protected virtual void OnDisable()
 		{
 			activeCharacters.Remove(this);
@@ -43,7 +43,7 @@ namespace Fungus
 		//
 		// ILocalizable implementation
 		//
-		
+
 		public virtual string GetStandardText()
 		{
 			return nameText;
@@ -58,7 +58,7 @@ namespace Fungus
 		{
 			return description;
 		}
-		
+
 		public virtual string GetStringId()
 		{
 			// String id for character names is CHARACTER.<Character Name>

--- a/Assets/Fungus/Narrative/Scripts/Commands/Say.cs
+++ b/Assets/Fungus/Narrative/Scripts/Commands/Say.cs
@@ -57,8 +57,13 @@ namespace Fungus
 
 			executionCount++;
 
-			// Override the active say dialog if needed
-			if (setSayDialog != null)
+            // Override the active say dialog if needed
+            if (character != null && character.setSayDialog != null)
+            {
+                SayDialog.activeSayDialog = character.setSayDialog;
+            }
+
+            if (setSayDialog != null)
 			{
 				SayDialog.activeSayDialog = setSayDialog;
 			}

--- a/Assets/Fungus/Narrative/Scripts/Commands/Say.cs
+++ b/Assets/Fungus/Narrative/Scripts/Commands/Say.cs
@@ -57,13 +57,13 @@ namespace Fungus
 
 			executionCount++;
 
-            // Override the active say dialog if needed
-            if (character != null && character.setSayDialog != null)
-            {
-                SayDialog.activeSayDialog = character.setSayDialog;
-            }
+			// Override the active say dialog if needed
+			if (character != null && character.setSayDialog != null)
+			{
+				SayDialog.activeSayDialog = character.setSayDialog;
+			}
 
-            if (setSayDialog != null)
+			if (setSayDialog != null)
 			{
 				SayDialog.activeSayDialog = setSayDialog;
 			}


### PR DESCRIPTION
The idea of this feature is simple - allow setting default say dialog for Character. It's useful when you have a long dialog with multiple characters with dedicated say dialogs - it's more comfortable to set only character for each say command and not set say dialog for each one explicite in the command.