### PR TITLE
Type factory class for constructing POD types like Color

### DIFF
--- a/Assets/Fungus/FungusScript/Scripts/FungusScript.cs
+++ b/Assets/Fungus/FungusScript/Scripts/FungusScript.cs
@@ -258,6 +258,9 @@ namespace Fungus
             unityTable["time"] = UserData.CreateStatic(typeof(Time));
             unityTable["fungusprefs"] = UserData.CreateStatic(typeof(FungusPrefs));
 
+			UserData.RegisterType(typeof(PODTypeFactory));
+			unityTable["factory"] = UserData.CreateStatic(typeof(PODTypeFactory));
+
             // This FungusScript object
             unityTable["fungusscript"] = this;
 

--- a/Assets/Fungus/FungusScript/Scripts/PODTypeFactory.cs
+++ b/Assets/Fungus/FungusScript/Scripts/PODTypeFactory.cs
@@ -1,0 +1,84 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Fungus
+{
+
+	/// <summary>
+	/// Factory class to create new instances of common POD value types used by Unity.
+	/// Supports the same types as the SerializedProperty class: Color, Vector2, Vector3, Vector4, Quaternion & Rect.
+	/// MoonSharp doesn't work well with these types due to internal interop issues with c#. 
+	/// Use these factory methods to constuct these types instead of using the __new function call in Lua.
+	/// </summary>
+	public static class PODTypeFactory  
+	{
+		/// <summary>
+		/// Returns a new Color object.
+		/// </summary>
+		/// <param name="r">The red component.</param>
+		/// <param name="g">The green component.</param>
+		/// <param name="b">The blue component.</param>
+		/// <param name="a">The alpha component.</param>
+		public static Color color(float r, float g, float b, float a)
+		{
+			return new Color(r,g,b,a);
+		}
+
+		/// <summary>
+		/// Returns a new Vector2 object.
+		/// </summary>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
+		public static Vector2 vector2(float x, float y)
+		{
+			return new Vector2(x,y);
+		}
+
+		/// <summary>
+		/// Returns a new Vector3 object.
+		/// </summary>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
+		/// <param name="z">The z coordinate.</param>
+		public static Vector3 vector3(float x, float y, float z)
+		{
+			return new Vector3(x,y,z);
+		}
+
+		/// <summary>
+		/// Returns a new Vector4 object.
+		/// </summary>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
+		/// <param name="z">The z coordinate.</param>
+		/// <param name="w">The w coordinate.</param>
+		public static Vector4 vector4(float x, float y, float z, float w)
+		{
+			return new Vector4(x,y,z,w);
+		}
+
+		/// <summary>
+		/// Returns a new Quaternion object representing a rotation.
+		/// </summary>
+		/// <param name="x">The x rotation in degrees.</param>
+		/// <param name="y">The y rotation in degrees.</param>
+		/// <param name="z">The z rotation in degrees.</param>
+		public static Quaternion quaternion(float x, float y, float z)
+		{
+			return UnityEngine.Quaternion.Euler(x,y,z);
+		}
+			
+		/// <summary>
+		/// Returns a new Rect object.
+		/// </summary>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
+		/// <param name="width">The rectangle width.</param>
+		/// <param name="height">The rectangle height.</param>
+		public static Rect rect(float x, float y, float width, float height)
+		{
+			return new Rect(x,y,width, height);
+		}
+	}
+
+}

--- a/Assets/Fungus/FungusScript/Scripts/PODTypeFactory.cs.meta
+++ b/Assets/Fungus/FungusScript/Scripts/PODTypeFactory.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7e3401d05b72e4960ad1b35a73e1571a
+timeCreated: 1459374585
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/FungusScript/FungusTests.unity
+++ b/Assets/Tests/FungusScript/FungusTests.unity
@@ -142,7 +142,6 @@ MonoBehaviour:
   - key: voiceover
     obj: {fileID: 8300000, guid: d2ab1fbe555d44e9e870311657856bdc, type: 3}
     component: {fileID: 0}
-  typeRegistry: {fileID: 0}
 --- !u!1 &13683311
 GameObject:
   m_ObjectHideFlags: 0
@@ -715,7 +714,6 @@ MonoBehaviour:
   - key: menudialog
     obj: {fileID: 560555132}
     component: {fileID: 560555134}
-  typeRegistry: {fileID: 0}
 --- !u!4 &36455799 stripped
 Transform:
   m_PrefabParentObject: {fileID: 495584, guid: 49031c561e16d4fcf91c12153f8e0b25, type: 2}
@@ -1274,7 +1272,6 @@ MonoBehaviour:
   - key: optionbutton0
     obj: {fileID: 876352038}
     component: {fileID: 876352041}
-  typeRegistry: {fileID: 0}
 --- !u!1 &190681717
 GameObject:
   m_ObjectHideFlags: 0
@@ -2738,7 +2735,6 @@ MonoBehaviour:
   - key: flowchart
     obj: {fileID: 1983492490}
     component: {fileID: 1983492495}
-  typeRegistry: {fileID: 0}
 --- !u!1 &507572619
 GameObject:
   m_ObjectHideFlags: 0
@@ -3617,7 +3613,6 @@ MonoBehaviour:
   - key: transform
     obj: {fileID: 328064332}
     component: {fileID: 328064333}
-  typeRegistry: {fileID: 0}
 --- !u!1001 &726346786
 Prefab:
   m_ObjectHideFlags: 0
@@ -4749,7 +4744,6 @@ MonoBehaviour:
   - key: 
     obj: {fileID: 0}
     component: {fileID: 0}
-  typeRegistry: {fileID: 0}
 --- !u!1 &928936324
 GameObject:
   m_ObjectHideFlags: 0
@@ -5024,7 +5018,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   nodeRect:
     serializedVersion: 2
-    x: 100
+    x: 98.90469
     y: 61
     width: 120
     height: 40
@@ -5060,8 +5054,8 @@ MonoBehaviour:
   version: 1
   scrollPos: {x: 32, y: -30}
   variablesScrollPos: {x: 0, y: 0}
-  variablesExpanded: 1
-  blockViewHeight: 400
+  variablesExpanded: 0
+  blockViewHeight: 251
   zoom: 0.9129947
   scrollViewRect:
     serializedVersion: 2
@@ -5071,7 +5065,7 @@ MonoBehaviour:
     height: 859
   selectedBlock: {fileID: 942227027}
   selectedCommands:
-  - {fileID: 942227038}
+  - {fileID: 942227053}
   variables:
   - {fileID: 942227029}
   - {fileID: 942227035}
@@ -5238,15 +5232,7 @@ MonoBehaviour:
   errorMessage: 
   indentLevel: 0
   fungusScript: {fileID: 715246548}
-  luaScript: 'local c = unity.color.__new()
-
-    c.r = 1
-
-    c.g = 0.5
-
-    c.b = 1
-
-    c.a = 1
+  luaScript: 'local c = unity.factory.color(1, 0.5, 1, 1)
 
 
     return c'
@@ -5419,11 +5405,8 @@ MonoBehaviour:
   errorMessage: 
   indentLevel: 0
   fungusScript: {fileID: 715246548}
-  luaScript: 'local v = unity.vector2.__new()
+  luaScript: 'local v = unity.factory.vector2(1,1)
 
-    v.x = 1
-
-    v.y =1
 
     return v'
   useFungusModule: 1
@@ -5493,13 +5476,7 @@ MonoBehaviour:
   errorMessage: 
   indentLevel: 0
   fungusScript: {fileID: 715246548}
-  luaScript: 'local v = unity.vector3.__new()
-
-    v.x = 1
-
-    v.y =1
-
-    v.z = 1
+  luaScript: 'local v = unity.factory.vector3(1,1,1)
 
     return v'
   useFungusModule: 1
@@ -6129,7 +6106,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1109996700
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8133,7 +8110,6 @@ MonoBehaviour:
   - key: flowchart
     obj: {fileID: 807616582}
     component: {fileID: 807616590}
-  typeRegistry: {fileID: 0}
 --- !u!1 &1738857300
 GameObject:
   m_ObjectHideFlags: 0
@@ -9626,7 +9602,6 @@ MonoBehaviour:
   - key: mousepointer
     obj: {fileID: 2800000, guid: efe8aa62cc87f4b70b9272e4e8e06668, type: 3}
     component: {fileID: 0}
-  typeRegistry: {fileID: 0}
 --- !u!1 &2119731355
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
MoonSharp’s __new function appears to be unreliable for POD types like
Color, Vector2, etc. This class provides simple factory methods for
constructing these types, which are then exposed through unity.factory
in Lua.