### PR TITLE
Rename non-coroutine Execute to StartExecute to be more descriptive

### DIFF
--- a/Assets/Fungus/Flowchart/Scripts/Block.cs
+++ b/Assets/Fungus/Flowchart/Scripts/Block.cs
@@ -145,9 +145,9 @@ namespace Fungus
 		/// <summary>
 		/// Start a coroutine which executes all commands in the Block. Only one running instance of each Block is permitted.
 		/// </summary>
-		public virtual void Execute()
+		public virtual void StartExecution()
 		{
-			StartCoroutine(Execute(0, null));
+			StartCoroutine(Execute());
 		}
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Fungus
         /// </summary>
         /// <param name="commandIndex">Index of command to start execution at</param>
         /// <param name="onComplete">Delegate function to call when execution completes</param>
-        public virtual IEnumerator Execute(int commandIndex, Action onComplete)
+        public virtual IEnumerator Execute(int commandIndex = 0, Action onComplete = null)
 		{
             if (executionState != ExecutionState.Idle)
             {

--- a/Assets/Fungus/Narrative/Scripts/MenuDialog.cs
+++ b/Assets/Fungus/Narrative/Scripts/MenuDialog.cs
@@ -130,7 +130,7 @@ namespace Fungus
 
 							gameObject.SetActive(false);
 
-							block.Execute();
+							block.StartExecution();
 						}
 					});
 
@@ -187,7 +187,7 @@ namespace Fungus
 
 			if (targetBlock != null)
 			{
-				targetBlock.Execute();
+				targetBlock.StartExecution();
 			}
 		}
 	}

--- a/Assets/Tests/FungusScript/FungusTests.unity
+++ b/Assets/Tests/FungusScript/FungusTests.unity
@@ -5064,8 +5064,7 @@ MonoBehaviour:
     width: 1114
     height: 859
   selectedBlock: {fileID: 942227027}
-  selectedCommands:
-  - {fileID: 942227053}
+  selectedCommands: []
   variables:
   - {fileID: 942227029}
   - {fileID: 942227035}


### PR DESCRIPTION
Lua scripts should use the coroutine Execute method directly.